### PR TITLE
README: use the fancy [!NOTE] annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Freezolite.setup(
 )
 ```
 
-**NOTE**: When using auto mode, the `<project-root>/vendor/bundle` folder is excluded automatically. In manual mode, you may want to exclude it yourself.
+> [!NOTE]
+> When using auto mode, the `<project-root>/vendor/bundle` folder is excluded automatically. In manual mode, you may want to exclude it yourself.
 
 ### Using with Bootsnap
 


### PR DESCRIPTION
I saw that there was a bold NOTE note in the README, and thought of this little GFM extension.